### PR TITLE
Fix intermittent data races

### DIFF
--- a/include/pmc/pmc_bool_vector.h
+++ b/include/pmc/pmc_bool_vector.h
@@ -1,55 +1,38 @@
 #ifndef PMC_BOOL_VECTOR_H_
 #define PMC_BOOL_VECTOR_H_
 
-#include <cstddef>
 #include <cstdint>
 #include <vector>
 
 namespace pmc {
+
 /// A bare minimum implementation of a boolean vector.
 ///
 /// This class is recommended in place of std::vector<bool> or std::vector<int> for thread-safety.
 /// std::vector<bool> could cause a race condition if it is implemented as a dynamic bitset.
 /// std::vector<int> is not memory efficient and misleading as an element can hold other than 0 or 1.
-class bool_vector {
-public:
-  bool_vector(std::size_t size = 0UL, bool value = false)
-      : data_(size, to_int(value)) {}
+class bool_wrapper {
+ public:
+  /// NOTE: It should not be marked `explicit` to allow implicit conversion from `bool` to `bool_wrapper`.
+  bool_wrapper(bool value = false) : byte_(to_int(value)) {}
 
-  std::size_t size() const noexcept { return data_.size(); }
+  operator bool() const noexcept { return byte_ != 0; }
 
-  bool empty() const noexcept { return data_.empty(); }
-
-  void resize(std::size_t size, bool value = false) {
-    data_.resize(size, to_int(value));
+  bool_wrapper& operator=(bool value) noexcept {
+    byte_ = to_int(value);
+    return *this;
   }
 
-  class Reference {
-  public:
-    Reference(std::uint8_t &byte) : byte_(byte) {}
-
-    operator bool() const noexcept { return byte_ != 0; }
-
-    Reference &operator=(bool value) noexcept {
-      byte_ = to_int(value);
-      return *this;
-    }
-
-  private:
-    std::uint8_t &byte_;
-  };
-
-  bool operator[](std::size_t i) const noexcept { return data_[i] != 0; }
-
-  Reference operator[](std::size_t i) noexcept { return Reference(data_[i]); }
-
-private:
+ private:
   static constexpr std::uint8_t to_int(bool value) noexcept {
     return value ? 1 : 0;
   }
 
-  std::vector<std::uint8_t> data_;
+  std::uint8_t byte_;
 };
+
+using bool_vector = std::vector<bool_wrapper>;
+
 } // namespace pmc
 
 #endif

--- a/include/pmc/pmc_graph.h
+++ b/include/pmc/pmc_graph.h
@@ -69,8 +69,8 @@ namespace pmc {
                     std::vector<int>& es,
                     const bool_vector& pruned);
 
-            int num_vertices() { return vertices.size() - 1; }
-            int num_edges() { return edges.size()/2; }
+            int num_vertices() const noexcept { return vertices.size() - 1; }
+            int num_edges() const noexcept { return edges.size()/2; }
             const std::vector <long long>& get_vertices() const noexcept { return vertices; }
             const std::vector<int>& get_edges() const noexcept { return edges; }
             std::vector<int>* get_degree(){ return &degree; }
@@ -78,19 +78,19 @@ namespace pmc {
             std::vector<long long> get_vertices_array() { return vertices; };
             std::vector<long long> e_v, e_u, eid;
 
-            int vertex_degree(int v) { return vertices[v] - vertices[v+1]; }
-            long long first_neigh(int v) { return vertices[v]; }
-            long long last_neigh(int v) { return vertices[v+1]; }
+            int vertex_degree(int v) const noexcept { return vertices[v] - vertices[v+1]; }
+            long long first_neigh(int v) const noexcept { return vertices[v]; }
+            long long last_neigh(int v) const noexcept { return vertices[v+1]; }
 
             void sum_vertex_degrees();
             void vertex_degrees();
             void update_degrees();
             void update_degrees(bool flag);
             void update_degrees(bool_vector& pruned, int& mc);
-            double density() { return (double)num_edges() / (num_vertices() * (num_vertices() - 1.0) / 2.0); }
-            int get_max_degree() { return max_degree; }
-            int get_min_degree() { return min_degree; }
-            double get_avg_degree() { return avg_degree; }
+            double density() const noexcept { return (double)num_edges() / (num_vertices() * (num_vertices() - 1.0) / 2.0); }
+            int get_max_degree() const noexcept { return max_degree; }
+            int get_min_degree() const noexcept { return min_degree; }
+            double get_avg_degree() const noexcept { return avg_degree; }
 
             void initialize();
             std::string get_file_extension(const std::string& filename);
@@ -109,7 +109,7 @@ namespace pmc {
             std::vector<int> kcore_order;
             std::vector<int>* get_kcores() { return &kcore; }
             std::vector<int>* get_kcore_ordering() { return &kcore_order; }
-            int get_max_core() { return max_core; }
+            int get_max_core() const noexcept { return max_core; }
             void update_kcores(const bool_vector& pruned);
 
             void compute_cores();

--- a/include/pmc/pmc_graph.h
+++ b/include/pmc/pmc_graph.h
@@ -71,8 +71,8 @@ namespace pmc {
 
             int num_vertices() { return vertices.size() - 1; }
             int num_edges() { return edges.size()/2; }
-            std::vector <long long>* get_vertices(){ return &vertices; }
-            std::vector<int>* get_edges(){ return &edges; }
+            const std::vector <long long>& get_vertices() const noexcept { return vertices; }
+            const std::vector<int>& get_edges() const noexcept { return edges; }
             std::vector<int>* get_degree(){ return &degree; }
             std::vector<int> get_edges_array() { return edges; }
             std::vector<long long> get_vertices_array() { return vertices; };

--- a/include/pmc/pmc_heu.h
+++ b/include/pmc/pmc_heu.h
@@ -32,8 +32,8 @@ namespace pmc {
 
     class pmc_heu {
         public:
-            std::vector<int>* E;
-            std::vector<long long>* V;
+            std::vector<int> const* E;
+            std::vector<long long> const* V;
             std::vector<int>* K;
             std::vector<int>* order;
             std::vector<int>* degree;

--- a/include/pmc/pmc_heu.h
+++ b/include/pmc/pmc_heu.h
@@ -20,6 +20,7 @@
 #ifndef PMC_HEU_H_
 #define PMC_HEU_H_
 
+#include "pmc/pmc_bool_vector.h"
 #include "pmc_graph.h"
 #include "pmc_input.h"
 #include "pmc_utils.h"
@@ -77,12 +78,12 @@ namespace pmc {
                 return (v.get_bound() < u.get_bound());
             }
 
-            int search(pmc_graph& graph, std::vector<int>& C_max);
-            int search_cores(pmc_graph& graph, std::vector<int>& C_max, int lb);
-            int search_bounds(pmc_graph& graph, std::vector<int>& C_max);
+            int search(const pmc_graph& graph, std::vector<int>& C_max);
+            int search_cores(const pmc_graph& graph, std::vector<int>& C_max, int lb);
+            int search_bounds(const pmc_graph& graph, std::vector<int>& C_max);
 
             inline void branch(std::vector<Vertex>& P, int sz,
-                    int& mc, std::vector<int>& C, std::vector<short>& ind);
+                    int& mc, std::vector<int>& C, bool_vector& ind);
 
             void print_info(const std::vector<int>& C_max) const;
     };

--- a/include/pmc/pmc_heu.h
+++ b/include/pmc/pmc_heu.h
@@ -84,7 +84,7 @@ namespace pmc {
             inline void branch(std::vector<Vertex>& P, int sz,
                     int& mc, std::vector<int>& C, std::vector<short>& ind);
 
-            inline void print_info(std::vector<int> C_max);
+            void print_info(const std::vector<int>& C_max) const;
     };
 };
 #endif

--- a/include/pmc/pmc_maxclique.h
+++ b/include/pmc/pmc_maxclique.h
@@ -32,8 +32,8 @@ namespace pmc {
 
     class pmc_maxclique {
         public:
-            std::vector<int>* edges;
-            std::vector<long long>* vertices;
+            std::vector<int> const* edges;
+            std::vector<long long> const* vertices;
             std::vector<int>* bound;
             std::vector<int>* order;
             std::vector<int>* degree;

--- a/include/pmc/pmc_vertex.h
+++ b/include/pmc/pmc_vertex.h
@@ -31,12 +31,12 @@ namespace pmc {
         private:
             int id, b;
         public:
-            Vertex(int vertex_id, int bound): id(vertex_id), b(bound) {};
+            Vertex(int vertex_id, int bound): id(vertex_id), b(bound) {}
 
-            void set_id(int vid) { id = vid; }
+            void set_id(int vid) noexcept { id = vid; }
             int get_id() const noexcept { return id; }
 
-            void set_bound(int value) { b = value; }
+            void set_bound(int value) noexcept { b = value; }
             int get_bound() const noexcept { return b; }
     };
 
@@ -47,7 +47,7 @@ namespace pmc {
         return (v.get_bound() < u.get_bound());
     };
 
-    inline static void print_mc_info(std::vector<int> &C_max, double sec) {
+    inline static void print_mc_info(const std::vector<int>& C_max, double sec) {
         DEBUG_PRINTF("*** [pmc: thread %i", omp_get_thread_num() + 1);
         DEBUG_PRINTF("]   current max clique = %i", C_max.size());
         DEBUG_PRINTF(",  time = %i sec\n", get_time() - sec);

--- a/include/pmc/pmc_vertex.h
+++ b/include/pmc/pmc_vertex.h
@@ -33,11 +33,11 @@ namespace pmc {
         public:
             Vertex(int vertex_id, int bound): id(vertex_id), b(bound) {};
 
-            void set_id(int vid)        { id = vid; }
-            int get_id()                { return id; }
+            void set_id(int vid) { id = vid; }
+            int get_id() const noexcept { return id; }
 
-            void set_bound(int value)   { b = value; }
-            int get_bound()             { return b; }
+            void set_bound(int value) { b = value; }
+            int get_bound() const noexcept { return b; }
     };
 
     static bool decr_bound(Vertex v,  Vertex u) {

--- a/include/pmc/pmcx_maxclique.h
+++ b/include/pmc/pmcx_maxclique.h
@@ -32,8 +32,6 @@ namespace pmc {
 
     class pmcx_maxclique {
         public:
-            std::vector<int>* edges;
-            std::vector<long long>* vertices;
             std::vector<int>* bound;
             std::vector<int>* order;
             int param_ub;

--- a/include/pmc/pmcx_maxclique_basic.h
+++ b/include/pmc/pmcx_maxclique_basic.h
@@ -32,8 +32,6 @@ namespace pmc {
 
     class pmcx_maxclique_basic {
         public:
-            std::vector<int>* edges;
-            std::vector<long long>* vertices;
             std::vector<int>* bound;
             std::vector<int>* order;
             std::vector<int>* degree;

--- a/pmc_heu.cpp
+++ b/pmc_heu.cpp
@@ -17,33 +17,33 @@
  ============================================================================
  */
 
+#include "pmc/pmc_bool_vector.h"
 #include "pmc/pmc_debug_utils.h"
 #include "pmc/pmc_heu.h"
 
 #include <algorithm>
 
 using namespace pmc;
-using namespace std;
 
 
-void pmc_heu::branch(vector<Vertex>& P, int sz,
-        int& mc, vector<int>& C, vector<short>& ind) {
+void pmc_heu::branch(std::vector<Vertex>& P, int sz,
+        int& mc, std::vector<int>& C, bool_vector& ind) {
 
     if (P.size() > 0) {
 
         int u = P.back().get_id();
         P.pop_back();
 
-        for (long long j = (*V)[u]; j < (*V)[u + 1]; j++)  ind[(*E)[j]] = 1;
+        for (long long j = (*V)[u]; j < (*V)[u + 1]; j++)  ind[(*E)[j]] = true;
 
-        vector <Vertex> R;
+        std::vector <Vertex> R;
         R.reserve(P.size());
         for (int i = 0; i < P.size(); i++)
             if (ind[P[i].get_id()])
                 if ((*K)[P[i].get_id()] > mc)
                     R.push_back(P[i]);
 
-        for (long long j = (*V)[u]; j < (*V)[u + 1]; j++)  ind[(*E)[j]] = 0;
+        for (long long j = (*V)[u]; j < (*V)[u + 1]; j++)  ind[(*E)[j]] = false;
 
         int mc_prev = mc;
         branch(R, sz + 1, mc, C, ind);
@@ -57,8 +57,8 @@ void pmc_heu::branch(vector<Vertex>& P, int sz,
     return;
 }
 
-int pmc_heu::search_bounds(pmc_graph& G,
-        vector<int>& C_max) {
+int pmc_heu::search_bounds(const pmc_graph& G,
+        std::vector<int>& C_max) {
 
     V = &G.get_vertices();
     E = &G.get_edges();
@@ -68,7 +68,7 @@ int pmc_heu::search_bounds(pmc_graph& G,
     std::vector<Vertex> P;
     P.reserve(G.get_max_degree()+1);
 
-    vector<short> ind(G.num_vertices(), 0);
+    bool_vector ind(G.num_vertices(), false);
 
     bool found_ub = false;
     int mc = 0, i;
@@ -122,15 +122,15 @@ int pmc_heu::compute_heuristic(int v) {
 }
 
 
-int pmc_heu::search_cores(pmc_graph& G, vector<int>& C_max, int lb) {
+int pmc_heu::search_cores(const pmc_graph& G, std::vector<int>& C_max, int lb) {
 
-    vector <int> C, X;
+    std::vector <int> C, X;
     C.reserve(ub);
     C_max.reserve(ub);
-    vector<Vertex> P, T;
+    std::vector<Vertex> P, T;
     P.reserve(G.get_max_degree()+1);
     T.reserve(G.get_max_degree()+1);
-    vector<short> ind(G.num_vertices(),0);
+    bool_vector ind(G.num_vertices(), false);
 
     int mc = lb, i;
 
@@ -176,12 +176,12 @@ int pmc_heu::search_cores(pmc_graph& G, vector<int>& C_max, int lb) {
 }
 
 
-int pmc_heu::search(pmc_graph& G, vector<int>& C_max) {
+int pmc_heu::search(const pmc_graph& G, std::vector<int>& C_max) {
     return search_bounds(G, C_max);
 }
 
 
-void pmc_heu::print_info(const vector<int>& C_max) const {
+void pmc_heu::print_info(const std::vector<int>& C_max) const {
     DEBUG_PRINTF("*** [pmc heuristic: thread %i", omp_get_thread_num() + 1);
     DEBUG_PRINTF("]   current max clique = %i", C_max.size());
     DEBUG_PRINTF(",  time = %i sec\n", get_time() - sec);

--- a/pmc_heu.cpp
+++ b/pmc_heu.cpp
@@ -62,24 +62,24 @@ int pmc_heu::search_bounds(pmc_graph& G,
 
     V = &G.get_vertices();
     E = &G.get_edges();
-    vector <int> C, X;
+    std::vector<int> C;
     C.reserve(ub);
     C_max.reserve(ub);
-    vector<Vertex> P, T;
+    std::vector<Vertex> P;
     P.reserve(G.get_max_degree()+1);
-    T.reserve(G.get_max_degree()+1);
-    vector<short> ind(G.num_vertices(),0);
+
+    vector<short> ind(G.num_vertices(), 0);
 
     bool found_ub = false;
-    int mc = 0, i, v, lb_idx = 0;
+    int mc = 0, i;
 
     #pragma omp parallel for schedule(dynamic) \
-        shared(G, X, mc, C_max, lb_idx) private(i, v, P, C) firstprivate(ind) \
+        shared(G, mc, C_max) private(i, P, C) firstprivate(ind) \
         num_threads(num_threads)
     for (i = G.num_vertices()-1; i >= 0; --i) {
         if (found_ub) continue;
 
-        v = (*order)[i];
+        const int v = (*order)[i];
         const auto mc_prev = mc;
         auto mc_cur = mc_prev;
 
@@ -87,7 +87,6 @@ int pmc_heu::search_bounds(pmc_graph& G,
             for (long long j = (*V)[v]; j < (*V)[v + 1]; j++)
                 if ((*K)[(*E)[j]] > mc_cur)
                     P.push_back( Vertex((*E)[j], compute_heuristic((*E)[j])) );
-
 
             if (P.size() > mc_cur) {
                 std::sort(P.begin(), P.end(), incr_heur);
@@ -104,7 +103,8 @@ int pmc_heu::search_bounds(pmc_graph& G,
                     }
                 }
             }
-            C = X; P = T;
+            C.clear();
+            P.clear();
         }
     }
     DEBUG_PRINTF("[pmc heuristic]\t mc = %i\n", mc);

--- a/pmc_heu.cpp
+++ b/pmc_heu.cpp
@@ -81,12 +81,12 @@ int pmc_heu::search_bounds(pmc_graph& G,
         if (found_ub) continue;
 
         v = (*order)[i];
-        int mc_prev = mc;
-        int mc_cur = mc;
+        const auto mc_prev = mc;
+        auto mc_cur = mc_prev;
 
-        if ((*K)[v] > mc) {
+        if ((*K)[v] > mc_cur) {
             for (long long j = (*V)[v]; j < (*V)[v + 1]; j++)
-                if ((*K)[(*E)[j]] > mc)
+                if ((*K)[(*E)[j]] > mc_cur)
                     P.push_back( Vertex((*E)[j], compute_heuristic((*E)[j])) );
 
 
@@ -145,8 +145,8 @@ int pmc_heu::search_cores(pmc_graph& G, vector<int>& C_max, int lb) {
     for (i = lb_idx; i <= G.num_vertices()-1; i++) {
 
         v = (*order)[i];
-        int mc_prev = mc;
-        int mc_cur = mc;
+        const auto mc_prev = mc;
+        auto mc_cur = mc_prev;
 
         if ((*K)[v] > mc_cur) {
             for (long long j = (*V)[v]; j < (*V)[v + 1]; j++)

--- a/pmc_heu.cpp
+++ b/pmc_heu.cpp
@@ -104,6 +104,11 @@ int pmc_heu::search_bounds(const pmc_graph& G,
                 std::sort(P.begin(), P.end(), incr_heur);
                 branch(P, 1 , mc_cur, C, ind);
 
+                if (mc_cur >= ub) {
+                    #pragma omp atomic write release
+                    found_ub = true;
+                }
+
                 if (mc_cur > mc_prev) {
                     #pragma omp atomic read acquire
                     mc_prev = mc;
@@ -111,11 +116,6 @@ int pmc_heu::search_bounds(const pmc_graph& G,
                     if (mc_cur > mc_prev) {
                         #pragma omp atomic write release
                         mc = mc_cur;
-
-                        if (mc_cur >= ub) {
-                            #pragma omp atomic write release
-                            found_ub = true;
-                        }
 
                         C.push_back(v);
 

--- a/pmc_heu.cpp
+++ b/pmc_heu.cpp
@@ -104,11 +104,6 @@ int pmc_heu::search_bounds(const pmc_graph& G,
                 std::sort(P.begin(), P.end(), incr_heur);
                 branch(P, 1 , mc_cur, C, ind);
 
-                if (mc_cur >= ub) {
-                    #pragma omp atomic write release
-                    found_ub = true;
-                }
-
                 if (mc_cur > mc_prev) {
                     #pragma omp atomic read acquire
                     mc_prev = mc;
@@ -116,6 +111,11 @@ int pmc_heu::search_bounds(const pmc_graph& G,
                     if (mc_cur > mc_prev) {
                         #pragma omp atomic write release
                         mc = mc_cur;
+
+                        if (mc_cur >= ub) {
+                            #pragma omp atomic write release
+                            found_ub = true;
+                        }
 
                         C.push_back(v);
 

--- a/pmc_heu.cpp
+++ b/pmc_heu.cpp
@@ -60,9 +60,8 @@ void pmc_heu::branch(vector<Vertex>& P, int sz,
 int pmc_heu::search_bounds(pmc_graph& G,
         vector<int>& C_max) {
 
-    V = G.get_vertices();
-    E = G.get_edges();
-    degree = G.get_degree();
+    V = &G.get_vertices();
+    E = &G.get_edges();
     vector <int> C, X;
     C.reserve(ub);
     C_max.reserve(ub);
@@ -134,6 +133,7 @@ int pmc_heu::search_cores(pmc_graph& G, vector<int>& C_max, int lb) {
     vector<short> ind(G.num_vertices(),0);
 
     int mc = lb, i;
+
     int lb_idx = 0, v = 0;
     for (i = G.num_vertices()-1; i >= 0; i--) {
         v = (*order)[i];

--- a/pmc_heu.cpp
+++ b/pmc_heu.cpp
@@ -29,28 +29,29 @@ using namespace pmc;
 void pmc_heu::branch(std::vector<Vertex>& P, int sz,
         int& mc, std::vector<int>& C, bool_vector& ind) {
 
-    if (P.size() > 0) {
+    if (!P.empty()) {
 
-        int u = P.back().get_id();
+        const int u = P.back().get_id();
         P.pop_back();
 
         for (long long j = (*V)[u]; j < (*V)[u + 1]; j++)  ind[(*E)[j]] = true;
 
-        std::vector <Vertex> R;
+        std::vector<Vertex> R;
         R.reserve(P.size());
-        for (int i = 0; i < P.size(); i++)
-            if (ind[P[i].get_id()])
-                if ((*K)[P[i].get_id()] > mc)
-                    R.push_back(P[i]);
+
+        std::copy_if(P.begin(), P.end(), std::back_inserter(R),
+                     [this, mc, &ind](const Vertex &v) -> bool {
+                       return ind[v.get_id()] && (*K)[v.get_id()] > mc;
+                     });
 
         for (long long j = (*V)[u]; j < (*V)[u + 1]; j++)  ind[(*E)[j]] = false;
 
-        int mc_prev = mc;
+        const int mc_prev = mc;
         branch(R, sz + 1, mc, C, ind);
 
         if (mc > mc_prev)  C.push_back(u);
 
-        R.clear();  P.clear();
+        P.clear();
     }
     else if (sz > mc)
         mc = sz;
@@ -89,7 +90,7 @@ int pmc_heu::search_bounds(const pmc_graph& G,
         if ((*K)[v] > mc_cur) {
             for (long long j = (*V)[v]; j < (*V)[v + 1]; j++)
                 if ((*K)[(*E)[j]] > mc_cur)
-                    P.push_back( Vertex((*E)[j], compute_heuristic((*E)[j])) );
+                    P.emplace_back((*E)[j], compute_heuristic((*E)[j]));
 
             if (P.size() > mc_cur) {
                 std::sort(P.begin(), P.end(), incr_heur);

--- a/pmc_maxclique.cpp
+++ b/pmc_maxclique.cpp
@@ -27,8 +27,8 @@ using namespace pmc;
 
 int pmc_maxclique::search(pmc_graph& G, vector<int>& sol) {
 
-    vertices = G.get_vertices();
-    edges = G.get_edges();
+    vertices = &G.get_vertices();
+    edges = &G.get_edges();
     degree = G.get_degree();
     bool_vector pruned(G.num_vertices());
     int mc = lb, i = 0, u = 0;
@@ -151,8 +151,8 @@ void pmc_maxclique::branch(
 
 int pmc_maxclique::search_dense(pmc_graph& G, vector<int>& sol) {
 
-    vertices = G.get_vertices();
-    edges = G.get_edges();
+    vertices = &G.get_vertices();
+    edges = &G.get_edges();
     degree = G.get_degree();
     auto adj = G.adj;
 

--- a/pmcx_maxclique.cpp
+++ b/pmcx_maxclique.cpp
@@ -28,9 +28,6 @@ using namespace pmc;
 
 int pmcx_maxclique::search(pmc_graph& G, vector<int>& sol) {
 
-    vertices = G.get_vertices();
-    edges = G.get_edges();
-//    degree = G.get_degree();
     bool_vector pruned(G.num_vertices());
     int mc = lb, i = 0, u = 0;
 
@@ -178,9 +175,6 @@ void pmcx_maxclique::branch(
  */
 int pmcx_maxclique::search_dense(pmc_graph& G, vector<int>& sol) {
 
-    vertices = G.get_vertices();
-    edges = G.get_edges();
-//    degree = G.get_degree();
     auto adj = G.adj;
 
     bool_vector pruned(G.num_vertices());

--- a/pmcx_maxclique_basic.cpp
+++ b/pmcx_maxclique_basic.cpp
@@ -27,8 +27,6 @@ using namespace pmc;
 
 int pmcx_maxclique_basic::search(pmc_graph& G, vector<int>& sol) {
 
-    vertices = G.get_vertices();
-    edges = G.get_edges();
     degree = G.get_degree();
     bool_vector pruned(G.num_vertices());
     int mc = lb, i = 0, u = 0;
@@ -179,8 +177,6 @@ void pmcx_maxclique_basic::branch(
 
 int pmcx_maxclique_basic::search_dense(pmc_graph& G, vector<int>& sol) {
 
-    vertices = G.get_vertices();
-    edges = G.get_edges();
     degree = G.get_degree();
     auto adj = G.adj;
 


### PR DESCRIPTION
There were data races from `mc` and `found_ub`. I have updated the variable accesses to be atomic, which is cheaper than locking a mutex. Also, I optimized the critical section to not block other threads. 